### PR TITLE
[mando] Step8 지연처리(잔돈반환)

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,16 +44,16 @@
         <li><button data-price='10000'>10000원</button></li>
       </ul>
       <ul class='money_count_list'>
-        <li data-price='10'><span>10</span>개</li>
-        <li data-price='50'><span>10</span>개</li>
-        <li data-price='100'><span>10</span>개</li>
-        <li data-price='500'><span>10</span>개</li>
-        <li data-price='1000'><span>10</span>개</li>
-        <li data-price='5000'><span>5</span>개</li>
-        <li data-price='10000'><span>2</span>개</li>
+        <li data-price='10'><span>0</span>개</li>
+        <li data-price='50'><span>0</span>개</li>
+        <li data-price='100'><span>0</span>개</li>
+        <li data-price='500'><span>0</span>개</li>
+        <li data-price='1000'><span>0</span>개</li>
+        <li data-price='5000'><span>0</span>개</li>
+        <li data-price='10000'><span>0</span>개</li>
       </ul>
       <div class="wallet_money_box">
-        <span>61600</span>원
+        <span>0</span>원
       </div>
     </div>
     <script type='module' src="./js/index.js"></script>

--- a/js/action.js
+++ b/js/action.js
@@ -8,9 +8,13 @@ class Action{
   }
   init(){
     this.wallet.inputMoneyIntoMachine = this.inputMoneyIntoMachine.bind(this);
+    this.vendingMachine.inputMoneyIntoWallet = this.inputMoneyIntoWallet.bind(this);
   }
   inputMoneyIntoMachine(price){
     this.vendingMachine.inputMoney(price);
+  }
+  inputMoneyIntoWallet(change){
+    this.wallet.inputMoney(change);
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -11,8 +11,11 @@ const vm = new VendingMachine({
 })
 
 const wallet = new Wallet({
-  walletWrap: document.querySelector('.walletWrap')
+  walletWrap: document.querySelector('.walletWrap'),
+  moneyData : {10: 10, 50: 10, 100: 10, 500: 10, 1000: 10, 5000: 5, 10000: 2}
 })
+
+wallet.init();
 
 const action = new Action({
   vendingMachine: vm,

--- a/js/index.js
+++ b/js/index.js
@@ -2,15 +2,7 @@ import {VendingMachine} from "./vendingMachine.js"
 import {Wallet} from "./wallet.js"
 import {Action} from "./Action.js"
 import {itemData} from "./itemData.js"
-
-function makeItemHtml({number, name, price}){
-  return `<li class="item" data-number=${number} data-price=${price}>
-  <dl>
-    <dt class='item_name'>${name}</dt>
-    <dd>${number}. ${price}</dd>
-  </dl>
-  </li>`
-}
+import {makeItemHtml} from "./template.js"
 
 const vm = new VendingMachine({
   vendingMachineWrap: document.querySelector('.vending_machine_wrap'),

--- a/js/template.js
+++ b/js/template.js
@@ -1,0 +1,10 @@
+function makeItemHtml({number, name, price}){
+  return `<li class="item" data-number=${number} data-price=${price}>
+  <dl>
+    <dt class='item_name'>${name}</dt>
+    <dd>${number}. ${price}</dd>
+  </dl>
+  </li>`
+}
+
+export {makeItemHtml}

--- a/js/vendingMachine.js
+++ b/js/vendingMachine.js
@@ -27,10 +27,10 @@ class VendingMachine{
     this.items = this.itemList.childNodes;
   }
   inputMoney(price){
-    clearTimeout(this.returnTimeoutID);    
-    this.increaseTotalMoney(price)
-    this.printMessage(`${price}원이 투입되었습니다!`)
-    this.highlightItems()
+    clearTimeout(this.returnTimeoutID);
+    this.increaseTotalMoney(price);
+    this.printMessage(`${price}원이 투입되었습니다!`);
+    this.highlightItems();
   }
   increaseTotalMoney(price){
     this.totalMoney.textContent = Number(this.totalMoney.textContent) + Number(price);
@@ -71,7 +71,7 @@ class VendingMachine{
   }
   run(){
     const item = this.getItem(this.selectedNumber);
-    this.returnTimeoutID = setTimeout(this.returnMoney.bind(this), this.delayTime); // 비동기 순서 다시 파악하기
+    this.returnTimeoutID = setTimeout(this.returnMoney.bind(this), this.delayTime);
 
     if(!this.isValidItem(item)) return;
 
@@ -83,16 +83,21 @@ class VendingMachine{
     this.highlightItems();
   }
   isValidItem(item){
+    return this.isWrongNumber(item) ? false : this.isExpensive(item) ? false : true;
+  }
+  isWrongNumber(item){
     if(!item){
       this.printMessage('해당 번호의 아이템이 존재하지 않습니다');
-      return false;
+      return true;
     }
+    return false
+  }
+  isExpensive(item){
     if(Number(item.dataset.price) > Number(this.totalMoney.textContent)){
       this.printMessage('돈이 부족합니다')
-      return false;
+      return true;
     }
-
-    return true;
+    return false
   }
   getItem(number){
     this.selectedNumber = null;

--- a/js/vendingMachine.js
+++ b/js/vendingMachine.js
@@ -114,7 +114,7 @@ class VendingMachine{
     const change = {};
     const priceUnits = [10000, 5000, 1000, 500, 100, 50, 10];
 
-    priceUnits.forEach(price =>{
+    priceUnits.forEach(price => {
       const [count, remainder] = [Math.floor(money/price), money%price];
       if(count) change[price] = count;
       money = remainder;

--- a/js/vendingMachine.js
+++ b/js/vendingMachine.js
@@ -71,10 +71,10 @@ class VendingMachine{
   }
   run(){
     const item = this.getItem(this.selectedNumber);
-    this.returnTimeoutID = setTimeout(this.returnMoney.bind(this), this.delayTime);
-
+    
     if(!this.isValidItem(item)) return;
-
+    
+    this.returnTimeoutID = setTimeout(this.returnMoney.bind(this), this.delayTime);
     const price = item.dataset.price;
     const itemName = item.querySelector('.item_name').textContent;
 

--- a/js/vendingMachine.js
+++ b/js/vendingMachine.js
@@ -1,11 +1,12 @@
 // 자판기의 데이터와 작동을 갖고 있는 클래스
 
 class VendingMachine{
-  constructor({vendingMachineWrap, itemData, template}){
+  constructor({vendingMachineWrap, itemData, template, delayTime = 3000}){
     this.vendingMachineWrap = vendingMachineWrap;
     this.itemList = this.vendingMachineWrap.querySelector('.item_list');
     this.logBox = this.vendingMachineWrap.querySelector('.log_box');
     this.totalMoney = this.vendingMachineWrap.querySelector('.vm_money_box > span');
+    this.delayTime = delayTime
     this.selectedNumber = null;
     this.timeoutID = null;
     this.items = null;
@@ -56,12 +57,9 @@ class VendingMachine{
   }
   selectItem({target:{tagName, textContent}}){
     if(tagName !== 'BUTTON') return;
-    
-    const delayTime = 3000;
-
     this.selectNumber(textContent);
     clearTimeout(this.timeoutID);
-    this.timeoutID = setTimeout(this.run.bind(this), delayTime);
+    this.timeoutID = setTimeout(this.run.bind(this), this.delayTime);
   }
   selectNumber(number){
     this.selectedNumber = this.selectedNumber || '';

--- a/js/vendingMachine.js
+++ b/js/vendingMachine.js
@@ -8,8 +8,8 @@ class VendingMachine{
     this.totalMoney = this.vendingMachineWrap.querySelector('.vm_money_box > span');
     this.delayTime = delayTime
     this.selectedNumber = null;
-    this.runTimeoutID = null; // 변수 명 수정
-    this.returnTimeoutID = null; // 변수 명 수정
+    this.runTimeoutID = null;
+    this.returnMoneyTimeoutID = null;
     this.items = null;
     this.inputMoneyIntoWallet = null;
 
@@ -27,7 +27,7 @@ class VendingMachine{
     this.items = this.itemList.childNodes;
   }
   inputMoney(price){
-    clearTimeout(this.returnTimeoutID);
+    clearTimeout(this.returnMoneyTimeoutID);
     this.increaseTotalMoney(price);
     this.printMessage(`${price}원이 투입되었습니다!`);
     this.highlightItems();
@@ -62,7 +62,7 @@ class VendingMachine{
     if(tagName !== 'BUTTON') return;
     this.selectNumber(textContent);
     clearTimeout(this.runTimeoutID);
-    clearTimeout(this.returnTimeoutID);
+    clearTimeout(this.returnMoneyTimeoutID);
     this.runTimeoutID = setTimeout(this.run.bind(this), this.delayTime);
   }
   selectNumber(number){
@@ -74,7 +74,7 @@ class VendingMachine{
     
     if(!this.isValidItem(item)) return;
     
-    this.returnTimeoutID = setTimeout(this.returnMoney.bind(this), this.delayTime);
+    this.returnMoneyTimeoutID = setTimeout(this.returnMoney.bind(this), this.delayTime);
     const price = item.dataset.price;
     const itemName = item.querySelector('.item_name').textContent;
 

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -7,18 +7,18 @@ class Wallet{
     this.moneyButtons = this.walletWrap.querySelectorAll('.money_button_list > li > button');
     this.moneyCountList = this.walletWrap.querySelector('.money_count_list'); // 리팩토링
     this.totalMoney = this.walletWrap.querySelector('.wallet_money_box > span');
-    this.moneyCountElemDict = this.makeMoneyCountElemDict(); // 이름에 Dict 가 사용되나요?
+    this.moneyCountElems = this.makeMoneyCountElemDict();
     this.inputMoneyIntoMachine = null;
   }
   init(){
     this.render();
     this.addEventListener();
     this.calcTotalMoney();
-    this.moneyData = null; // 더 이상 moneyData를 사용하지 않으므로 GC를 고려해서 초기화
+    this.moneyData = null;
   }
   render(){
     for(let [price, count] of Object.entries(this.moneyData)){
-      const moneyCountElem = this.moneyCountElemDict[price];
+      const moneyCountElem = this.moneyCountElems[price];
       moneyCountElem.textContent = count;
     }
   }
@@ -39,7 +39,7 @@ class Wallet{
   calcTotalMoney(){
     let totalMoney = 0;
 
-    for(let [price, {textContent:count}] of Object.entries(this.moneyCountElemDict)){
+    for(let [price, {textContent:count}] of Object.entries(this.moneyCountElems)){
       totalMoney += price * count;
     }
 
@@ -49,7 +49,7 @@ class Wallet{
     if(target.tagName !== 'BUTTON') return;
     
     const price = target.dataset.price;
-    const moneyCountElem = this.moneyCountList.querySelector(`[data-price='${price}']>span`);
+    const moneyCountElem = this.moneyCountElems[price];
     
     if(this.isZeroCount(moneyCountElem)) return;
 
@@ -65,7 +65,7 @@ class Wallet{
   }
   inputMoney(change){
     for(let [price, count] of Object.entries(change)){
-      const moneyCountElem = this.moneyCountElemDict[price];
+      const moneyCountElem = this.moneyCountElems[price];
       this.manipulateMoneyCount(moneyCountElem, count);
     }
     this.calcTotalMoney();

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -5,7 +5,7 @@ class Wallet{
     this.walletWrap = walletWrap;
     this.moneyData = moneyData;
     this.moneyButtons = this.walletWrap.querySelectorAll('.money_button_list > li > button');
-    this.moneyCountList = this.walletWrap.querySelector('.money_count_list'); // 리팩토링
+    this.moneyCountList = this.walletWrap.querySelector('.money_count_list');
     this.totalMoney = this.walletWrap.querySelector('.wallet_money_box > span');
     this.moneyCountElems = this.makeMoneyCountElemDict();
     this.inputMoneyIntoMachine = null;
@@ -25,7 +25,7 @@ class Wallet{
   addEventListener(){
     this.walletWrap.addEventListener('click', this.selectMoney.bind(this));
   }
-  makeMoneyCountElemDict(){ // reduce?
+  makeMoneyCountElemDict(){
     const moneyCountElemDict = {};
 
     this.moneyButtons.forEach( button => {

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -14,7 +14,7 @@ class Wallet{
     if(target.tagName !== 'BUTTON') return;
     
     const price = target.dataset.price;
-    const moneyCount = this.moneyCountList.querySelector(`[data-price='${price}']>span`);    
+    const moneyCount = this.moneyCountList.querySelector(`[data-price='${price}']>span`);
     
     if(this.isZeroCount(moneyCount)) return;
 
@@ -30,6 +30,26 @@ class Wallet{
   }
   decreaseTotalMoney(price){
     this.totalmoney.textContent -= price;
+  }
+  inputMoney(change){
+    for(let price in change){
+      let count = change[price]; // 한번에 받아오기
+      this.increaseMoney(price, count);
+    }
+  }
+  increaseMoney(price, count){
+    const moneyCount = this.moneyCountList.querySelector(`[data-price='${price}']>span`);
+
+    while(count-- > 0){
+      this.increaseMoneyCount(moneyCount); // decrease와 중복
+      this.increaseTotalMoney(price); // decrease와 중복
+    }
+  }
+  increaseMoneyCount(moneyCount){
+    moneyCount.textContent = Number(moneyCount.textContent) + 1;
+  }
+  increaseTotalMoney(price){
+    this.totalmoney.textContent = Number(this.totalmoney.textContent) + Number(price);
   }
 }
 


### PR DESCRIPTION
# 웹자판기 기능추가 및 리팩토링

#### 잔돈 반환 기능 구현

* `Action`을 통해 자판기에서 지갑으로 잔돈을 넘겨주기로 함

  * 잔돈은 어떤 형태여야 할까?
    * 처음에는 단순히 문자열 데이터를 넘겨줌.`"450"`
    * 근데 현실에서는 자판기가 잔돈을 화폐단위로(100원별로, 500원 별로) 변환시켜 사용자에게 전달해줌
    * 게다가 지갑에서 돈의 단위별로 쪼개서 넣어짐
    * 그렇다면 key-value형태의 객체가 좋다고 생각.`{50:1, 100:4}`
    * 잔돈객체는 현실의 경우에 따라 자판기에서 생성되도록 함
  * 잔돈 생성 규칙
    * 가장 큰 화폐 단위부터 잔돈을 나누기로 함
  * 문제점
    * 돈 데이터 형태가 지갑 > 자판기 이동할때`문자열`와 자판기 > 지갑 이동할 때`객체`가 다르다는 문제
    * 통일성이냐 효율성이냐: 지금은 효율성을 택했지만 왠지 통일성을 택하는 순간이 올 것 같다(모듈단위로 리팩토링한다고 가정하면 통일된 자료구조 형태가 더 좋을 것 같다)
* 지연 처리 기능

  * timeoutID와 clearTimeout을 이용해 비동기 동작 다룸

#### wallet 클래스 리팩토링

##### 1) 생성자의 인자로 각 돈 데이터를 받도록 변경

- render함수 필요

##### 2) Wallet클래스에서 이루어지는 작업은

1. price에 매칭되는 카운트 조작
2. totalMoney 조작

뿐이다. 현재 1번작업을 수행할 경우 매번 querySelector로 해당되는 엘리먼트를 찾고 있다. 효율성을 늘리기 위해서 미리 wallet클래스 프로퍼티로 `{price: countElem}`형태의 자료(moneyCountElemDict)가 있으면 좋겠다는 생각이 들었다.

##### 3) 새로운 생성자 규칙

wallet클래스 생성자에서는 객체의 속성만 초기화 시키기로 함

render및 이벤트 등록은 `init()`을 통해 외부에서 초기화 하도록 설정

##### 4) 지갑 전체금액을 계산하는 메소드 추가: calcTotalMoney()

increase와 decrease에서 전체 금액을 계산하는 로직이 중복되서 생성

##### 5) moneyCount를 조작하는 메소드 추가: manipulateMoneyCount(Elem, count)

count를 통해 음수와 양수값 모두 받도록 함. increase decrease에서 발생하는 중복을 제거하고, 범용성 있는 메소드를 만들기 위해 구현

#### 질문

Q. 데이터의 형태를 변수에 명시해 주는게 좋은가요?

ex) 리스트 형태의 item : itemList

딕셔너리 형태의 item : itemDict